### PR TITLE
Fix extra diagonal line on routes

### DIFF
--- a/packages/transit/src/route-layer.tsx
+++ b/packages/transit/src/route-layer.tsx
@@ -21,6 +21,7 @@ interface State {
 // Mapbox renders routes better if they're single LineString features, so we coalesce.
 // TODO: get r5 to return LineStrings directly?
 function coalesceFeatures(geojson: FeatureCollection): FeatureCollection {
+  // Perform a deep copy to prevent appending to a modified geojson.
   const features: Array<GeoJSONFeature<LineString>> = JSON.parse(
     JSON.stringify(geojson.features),
   ) as any;


### PR DESCRIPTION
Each update further mutates the state of the underlying geojson.features object passed in by root. Lots of interesting/different things can happen as you swap between different transit modes.

Deep copy seems to fix the issue!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/ttx/29)
<!-- Reviewable:end -->
