### PR TITLE
Comparison choropleth

### DIFF
--- a/packages/transit/src/ramps.ts
+++ b/packages/transit/src/ramps.ts
@@ -56,19 +56,19 @@ export const ORIGIN_COMPARISON = scaleThreshold<number, string>()
   .range(ORIGIN_COMPARISON_COLORS);
 
 export const SETTINGS_COMPARISON_COLORS = [
-  'rgba(  0,  83, 120, 0.6)', // blue
-  'rgba( 63, 108, 140, 0.6)',
-  'rgba(102, 135, 161, 0.6)',
-  'rgba(138, 162, 182, 0.6)',
-  'rgba(174, 190, 204, 0.6)',
-  'rgba(211, 219, 226, 0.6)',
-  'rgba(255, 255, 255, 0.6)', // white (equal times)
-  'rgba(255, 198, 196, 0.6)',
-  'rgba(242, 156, 163, 0.6)',
-  'rgba(218, 116, 137, 0.6)',
-  'rgba(185,  80, 115, 0.6)',
-  'rgba(147,  52,  93, 0.6)',
-  'rgba(103,  32,  68, 0.6)', // purple
+  'rgba(  0, 137, 248, 0.8333)', // dark blue
+  'rgba(  9, 145, 255, 0.8333)',
+  'rgba(  9, 145, 255, 0.6667)',
+  'rgba(  9, 145, 255, 0.5)', // half blue
+  'rgba( 90, 174, 230, 0.5)',
+  'rgba(171, 204, 205, 0.5)',
+  'rgba(252, 234, 180, 0.5)', // yellow
+  'rgba(168, 222, 124, 0.5)',
+  'rgba( 84, 210,  68, 0.5)',
+  'rgba(  0, 199, 13, 0.5)', // half green
+  'rgba(  0, 199, 13, 0.6667)',
+  'rgba(  0, 199, 13, 0.8333)',
+  'rgba(  0, 173, 11, 0.8333)', // green
 ];
 
 export const SETTINGS_COMPARISON = scaleThreshold<number, string>()

--- a/packages/transit/static/style/transit.css
+++ b/packages/transit/static/style/transit.css
@@ -265,7 +265,7 @@ span.close-button:hover {
 .swatch {
   display: inline-block;
   height: 16px;
-  flex: 1 0 20px;
+  flex: 1 0 16px;
 }
 
 .label-top,


### PR DESCRIPTION
This is more an interpretation of Alison's mocks, which called for a fade from blue/green to translucent, with an opaque yellow band for roughly equal times. I don't think this makes much sense visually; the yellow is too different from the surrounding bands.

I tried fading from blue/green to the neutral yellow, keeping opacity constant, but this had a muddy look to it that I didn't like.

I wound up fading from 80% opaque blue/green to 50% opaque blue/green, then to 50% opaque yellow:

![image](https://user-images.githubusercontent.com/98301/39478368-3c7010fe-4d30-11e8-99ba-9e1657d0f244.png)

Literal interpretation of mocks:
![image](https://user-images.githubusercontent.com/98301/39478638-021455fe-4d31-11e8-8eb5-fba02d601ab4.png)

Fade through yellow:
![image](https://user-images.githubusercontent.com/98301/39478669-138e4af6-4d31-11e8-827d-170365f75c95.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/ttx/32)
<!-- Reviewable:end -->
