### PR TITLE
Allow hover on destination marker

### DIFF
--- a/packages/transit/src/map-panel.tsx
+++ b/packages/transit/src/map-panel.tsx
@@ -25,10 +25,10 @@ interface State {
   } | null;
 }
 
-const TWO_HOURS_SECS = 2 * 60 * 60;
+const THREE_HOURS_SECS = 3 * 60 * 60;
 
 function isValidCommute(x: number) {
-  return x !== null && x !== undefined && x <= TWO_HOURS_SECS;
+  return x !== null && x !== undefined && x <= THREE_HOURS_SECS;
 }
 
 function makeStyleFn(args: Pick<ViewProps, 'mode' | 'times' | 'times2'>) {


### PR DESCRIPTION
This has a satisfying "snap" as you drag near the marker:

![hover snap](https://user-images.githubusercontent.com/98301/39479869-8818092c-4d34-11e8-9e84-86f07d981f99.gif)

I actually like it so much that I think we might want to _always_ have this on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/ttx/33)
<!-- Reviewable:end -->
