### PR TITLE
Fix color bug causing whitescreen

### DIFF
--- a/packages/transit/src/route-layer.tsx
+++ b/packages/transit/src/route-layer.tsx
@@ -52,7 +52,7 @@ function makeStyledFeatures(geojson: FeatureCollection): FeatureCollection {
       const {properties} = f;
       const stroke = properties.stroke === '#null' ? '#000000' : properties.stroke;
       const isBicycle = properties.mode === 'BICYCLE';
-      const lineColor = isBicycle ? BICYCLE_STROKE : stroke || '#000000';
+      const lineColor = isBicycle ? BICYCLE_STROKE : stroke;
       const lineOutlineColor = isBicycle ? BICYCLE_OUTLINE : mixColors(lineColor, '#000000');
       return {
         ...f,


### PR DESCRIPTION
Fix whitescreen from color error when clicking in certain places (https://swlabs.atlassian.net/browse/AP-291).

The underlying behavior comes from some of the routes having null colors. At this point stroke has the value '#null' rather than null, so the old default setting code didn't fix the issue.

https://github.com/sidewalklabs/ttx/blob/2b79bf5352a1b63a08e45d8ad74cf679c7e7201e/packages/transit/src/toronto-routes.ts#L2535

Not really sure why my other change is appearing in this PR, its already merged into master :/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/ttx/37)
<!-- Reviewable:end -->
