### PR TITLE
Add 2 min penalty to all transfers

### DIFF
--- a/packages/transit/common/r5-types.ts
+++ b/packages/transit/common/r5-types.ts
@@ -18,7 +18,7 @@ export interface ProfileRequest {
   directModes?: string; // comma-separated list of LegModes
   transitModes?: string; // comma-separated list of TransitModes
   bikeSpeed?: number; // speed of biking in meters per second
-  transferTimeCost?: number; // seconds to add to transfer time for confusion, delay, imperfection
+  transferPenaltySecs?: number; // seconds to add to transfer time for confusion, delay, imperfection
   verbose?: boolean;
 }
 

--- a/packages/transit/server/r5/r5.ts
+++ b/packages/transit/server/r5/r5.ts
@@ -76,7 +76,7 @@ function paramsToProfileRequest(
     transitModes: transitModes.join(),
     directModes: directModes.join(),
     verbose: true,
-    transferTimeCost: 300, // Default to 5 minutes cost per transfer.
+    transferPenaltySecs: 300, // Default to 5 minutes cost per transfer.
     wheelchair,
   };
   // Handle optional parameters.


### PR DESCRIPTION
Full disclosure, this doesn't fix all the problems; occasionally you still get a weird transfer on this query http://totx.sidewalklabs.com/#{%22origin%22:{%22lat%22:43.697907076049006,%22lng%22:-79.52606793775799},%22options%22:{%22bus_multiplier%22:1},%22dest%22:{%22lat%22:43.781712038845086,%22lng%22:-79.40780169121179}} if you happen to catch the bus at exactly the right time (if you keep refreshing you'll keep getting different time estimates because of the fact that it looks randomly for a start time).

I tried that query at a bunch of places on that street, and it does seem like there is some magic turning point where taking that bus truly is faster than walking that stretch, so it feels like there's a bit of method to the madness.

BUT I tried it with several other queries, and it definitely reduces the overall number of transfers effectively. See here: https://swlabs.atlassian.net/projects/AP/issues/AP-289

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/ttx/53)
<!-- Reviewable:end -->
