### PR TITLE
Put Bike & Transit on page 1

### DIFF
--- a/packages/transit/src/travel-mode-selector.tsx
+++ b/packages/transit/src/travel-mode-selector.tsx
@@ -75,12 +75,12 @@ function TravelModeCarousel(props: SingleProps): JSX.Element {
       swipeToSlide={true}
       variableWidth={true}
       infinite={false}>
-      <ModeTile mode="WALK" {...props} />
       <ModeTile mode="TRANSIT" {...props} />
-      <ModeTile mode="BICYCLE_RENT" {...props} />
       <ModeTile mode="BICYCLE" {...props} />
+      <ModeTile mode="BICYCLE_RENT" {...props} />
       <ModeTile mode="BICYCLE_RENT+TRANSIT" {...props} />
       <ModeTile mode="WHEELCHAIR" {...props} />
+      <ModeTile mode="WALK" {...props} />
     </Slider>
   );
 }


### PR DESCRIPTION
This makes it clearer what's going on when you click "+" to show bike vs. transit. We can come up with a more complete solution in the future.
![image](https://user-images.githubusercontent.com/98301/39586629-83d7d148-4ec5-11e8-8caa-26ad017e5a02.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/ttx/54)
<!-- Reviewable:end -->
