### PR TITLE
Roll back @types/mapboxgl version; react-mapbox-gl hasn't been update…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/js-cookie": "^2.0.28",
     "@types/json-stable-stringify": "^1.0.29",
     "@types/lodash": "^4.14.104",
-    "@types/mapbox-gl": "^0.45.0",
+    "@types/mapbox-gl": "^0.44.1",
     "@types/mocha": "^2.2.39",
     "@types/node-cache": "^3.0.31",
     "@types/prop-types": "^15.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,9 +162,9 @@
   version "4.14.104"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.104.tgz#53ee2357fa2e6e68379341d92eb2ecea4b11bb80"
 
-"@types/mapbox-gl@^0.45.0":
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-0.45.0.tgz#6ab6c6a7abd3422b006725be07630e77e141f70e"
+"@types/mapbox-gl@^0.44.1":
+  version "0.44.4"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-0.44.4.tgz#3bccd8460038cc857cbe610c92f6a54e4d16b873"
   dependencies:
     "@types/geojson" "*"
 


### PR DESCRIPTION
…d since mapboxgl 0.45 came out

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/totx/69)
<!-- Reviewable:end -->
