### PR TITLE
Change departure time for both modes on time change in comparison mode

### DIFF
--- a/packages/transit/src/datastore.ts
+++ b/packages/transit/src/datastore.ts
@@ -533,6 +533,10 @@ function createStore() {
       options = _.extend({}, options, action.options);
     }
 
+    if (action.options.departure_time && mode === 'compare-settings') {
+      options2.departure_time = options.departure_time;
+    }
+
     getCommuteTimePromises()
       .then(stateChanged)
       .catch(stateChanged);


### PR DESCRIPTION
In response to #70 
Added a check for when the departure time is being changed and we are in comparison mode. If yes then the new departure time set for options (mode A) will also be set for options2 (mode B)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/totx/72)
<!-- Reviewable:end -->
