### PR TITLE
Make dark colors less opaque for street visibility and darken central…

### DIFF
--- a/packages/transit/src/ramps.ts
+++ b/packages/transit/src/ramps.ts
@@ -5,8 +5,8 @@
 import {scaleThreshold} from 'd3-scale';
 
 export const SINGLE_COLORS = [
-  'rgba(  0, 137, 248, 1.0)', // dark blue
-  'rgba(  9, 145, 255, 0.8333)',
+  'rgba(  0, 123, 214, 0.8)', // dark blue
+  'rgba(  9, 145, 255, 0.7667)',
   'rgba(  9, 145, 255, 0.6667)',
   'rgba(  9, 145, 255, 0.5)',
   'rgba(  9, 145, 255, 0.3333)',


### PR DESCRIPTION
… color.

This is per user request:
"The readability of the Toronto Transit Explorer map would benefit with the overlay being a bit more transparent so you can still see the road network."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/totx/78)
<!-- Reviewable:end -->
